### PR TITLE
Support passing in pre-concated visitorLists directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function install(opts) {
   }
 
   var visitors = (opts.visitors || []).reduce(function (visitors, visitor) {
-    return visitors.concat(visitor.visitorList)
+    return visitors.concat(visitor.visitorList || visitor)
   }, [])
 
   require.extensions['.js'] = function (module, filename) {


### PR DESCRIPTION
For more flexibility, support accepting `opts.visitors` as a
pre-concatenated list of `visitorList`s.
